### PR TITLE
Support for datetime.date objects for date-like query fields

### DIFF
--- a/docs/tutorials/query_fields.rst
+++ b/docs/tutorials/query_fields.rst
@@ -105,6 +105,8 @@ Field Definitions
 
 **Time related**
 
+For those fields you can either pass instance of datetime.date or date-like string.
+
 .. glossary::
 
     BEFORE('date-like')

--- a/redbox/query/__init__.py
+++ b/redbox/query/__init__.py
@@ -1,4 +1,4 @@
-from .query import Flag, ValueField, KeyValueField, ALL, OR, NOT, BaseField
+from .query import Flag, ValueField, DateField, KeyValueField, ALL, OR, NOT, BaseField
 
 HEADER = KeyValueField("HEADER")
 
@@ -21,7 +21,6 @@ OLD = Flag("OLD")
 SEEN = Flag("SEEN")
 UNSEEN = Flag("UNSEEN")
 
-
 BCC = ValueField("BCC")
 CC = ValueField("CC")
 
@@ -32,15 +31,13 @@ BODY = ValueField("BODY")
 TO = ValueField("TO")
 FROM = ValueField("FROM")
 
-ON = ValueField("ON")
+SENTBEFORE = DateField("SENTBEFORE")
+SENTON = DateField("SENTON")
+SENTSINCE = DateField("SENTSINCE")
 
-
-SENTON = ValueField("SENTON")
-SENTBEFORE = ValueField("SENTBEFORE")
-SENTSINCE = ValueField("SENTSINCE")
-
-BEFORE = ValueField("BEFORE")
-SINCE = ValueField("SINCE")
+BEFORE = DateField("BEFORE")
+ON = DateField("ON")
+SINCE = DateField("SINCE")
 
 LARGER = ValueField("LARGER")
 SMALLER = ValueField("SMALLER")
@@ -49,7 +46,8 @@ UID = ValueField("UID")
 KEYWORD = ValueField("KEYWORD")
 UNKEYWORD = ValueField("UNKEYWORD")
 
-def _build(key:str, val):
+
+def _build(key: str, val):
     # Turning from_ --> "FROM", "to" --> "TO" etc.
     key = key.upper().rstrip("_")
     obj = BaseField._fields[key]
@@ -68,6 +66,7 @@ def _build(key:str, val):
             yield obj(*val)
     else:
         raise TypeError("Invalid field")
+
 
 def build(**kwargs) -> str:
     qry = None

--- a/redbox/tests/test_query.py
+++ b/redbox/tests/test_query.py
@@ -16,7 +16,7 @@ from datetime import datetime
         pytest.param(NOT(UNSEEN), '(NOT (UNSEEN))'),
         pytest.param(~UNSEEN, '(NOT (UNSEEN))'),
 
-        pytest.param(SINCE("2022-01-01"), '(SINCE "2022-01-01")'),
+        pytest.param(SINCE("01-Jan-2022"), '(SINCE "01-Jan-2022")'),
         pytest.param(SINCE(datetime(2022, 1, 1)), '(SINCE "01-Jan-2022")'),
         pytest.param(HEADER("Mime-Version", "1.0"), '(HEADER "Mime-Version" "1.0")'),
 
@@ -37,9 +37,9 @@ def test_expression(qry, expected):
         pytest.param(dict(unseen=False), '(NOT (UNSEEN))'),
         pytest.param(dict(seen=True), '(SEEN)'),
         pytest.param(dict(seen=False), '(NOT (SEEN))'),
-        pytest.param(dict(since="2022-01-01"), '(SINCE "2022-01-01")'),
+        pytest.param(dict(since="01-Jan-2022"), '(SINCE "01-Jan-2022")'),
         pytest.param(dict(header=('Mime-Version', '1.0')), '(HEADER "Mime-Version" "1.0")'),
-        pytest.param(dict(since="2022-01-01", seen=True), '(ALL (SINCE "2022-01-01") (SEEN))'),
+        pytest.param(dict(since="01-Jan-2022", seen=True), '(ALL (SINCE "01-Jan-2022") (SEEN))'),
         pytest.param(dict(since=datetime(2022, 1, 1), seen=True), '(ALL (SINCE "01-Jan-2022") (SEEN))'),
 
         pytest.param(dict(from_="me@example.com"), '(FROM "me@example.com")'),

--- a/redbox/tests/test_query.py
+++ b/redbox/tests/test_query.py
@@ -1,6 +1,6 @@
-
 import pytest
 from redbox.query import ALL, NEW, OR, TO, UNSEEN, SINCE, RECENT, NOT, TEXT, HEADER, SUBJECT, SEEN, build
+from datetime import datetime
 
 # A282 SEARCH FLAGGED SINCE 1-Feb-1994 NOT FROM "Smith"
 
@@ -17,6 +17,7 @@ from redbox.query import ALL, NEW, OR, TO, UNSEEN, SINCE, RECENT, NOT, TEXT, HEA
         pytest.param(~UNSEEN, '(NOT (UNSEEN))'),
 
         pytest.param(SINCE("2022-01-01"), '(SINCE "2022-01-01")'),
+        pytest.param(SINCE(datetime(2022, 1, 1)), '(SINCE "01-Jan-2022")'),
         pytest.param(HEADER("Mime-Version", "1.0"), '(HEADER "Mime-Version" "1.0")'),
 
         pytest.param(NOT(NEW & TEXT("hello")), '(NOT (ALL (NEW) (TEXT "hello")))'),
@@ -39,6 +40,7 @@ def test_expression(qry, expected):
         pytest.param(dict(since="2022-01-01"), '(SINCE "2022-01-01")'),
         pytest.param(dict(header=('Mime-Version', '1.0')), '(HEADER "Mime-Version" "1.0")'),
         pytest.param(dict(since="2022-01-01", seen=True), '(ALL (SINCE "2022-01-01") (SEEN))'),
+        pytest.param(dict(since=datetime(2022, 1, 1), seen=True), '(ALL (SINCE "01-Jan-2022") (SEEN))'),
 
         pytest.param(dict(from_="me@example.com"), '(FROM "me@example.com")'),
 


### PR DESCRIPTION
Hi,

Currently date-like query fields are accepting strings. This PR adds support for using datetime.date/datetime objects.

Current string values were just stored without any format check, e.g. tests are using value of '2022-01-01', which does not conform to RFC [1]. To summarize:
- string values are stored as before (to have backward compatibility) [2]
- date objects are being translated to RFC format, e.g. "01-Jan-2022"

[1] When I try to use "yyyy-mm-dd" format, gmail raises "Could not parse command" error, not sure if other email providers support such constructs, but I believe it's safer to use RFC format
[2] I couldn't find any examples in documentation that are using this invalid date format, but I've also updated tests to use RFC conforming format -> hopefully this will improve interoperability - by someone not blindly copying examples that may not be supported by email providers