### PR TITLE
Added handling singlepart emails

### DIFF
--- a/redbox/tests/examples/INBOX/3.eml
+++ b/redbox/tests/examples/INBOX/3.eml
@@ -1,0 +1,10 @@
+From: redacated_from@gmail.com
+MIME-Version: 1.0
+Date: Wed, 22 Mar 2023 06:44:05 -0700
+Message-ID: <redacted_message_id@mail.gmail.com>
+Subject: redacted subject
+To: redacated_to@gmail.com
+Content-Type: text/plain; charset="UTF-8"
+
+line 1
+line 2

--- a/redbox/tests/test_fetch.py
+++ b/redbox/tests/test_fetch.py
@@ -13,7 +13,7 @@ ROOT = Path(PATH_TEST).parent / "examples"
 
 def test_fetch(IMAP4):
     box = EmailBox(host="localhost", port=0, cls_imap=DummyGmailImap)
-    
+
     msg = EmailMessage(uid=1, session=box.inbox.session, mailbox="MYBOX")
     assert msg.content == (ROOT / "MYBOX/1.eml").read_text()
     assert isinstance(msg.email, Message)
@@ -49,7 +49,7 @@ def test_fetch(IMAP4):
 
 def test_set_flags(IMAP4):
     box = EmailBox(host="localhost", port=0, cls_imap=DummyGmailImap)
-    
+
     msg = EmailMessage(uid=1, session=box.inbox.session, mailbox="MYBOX")
     assert msg.seen
     assert msg.flagged
@@ -62,12 +62,12 @@ def test_set_flags(IMAP4):
 
 def test_set_flags_methods(IMAP4):
     box = EmailBox(host="localhost", port=0, cls_imap=DummyGmailImap)
-    
+
     msg = EmailMessage(uid=2, session=box.inbox.session, mailbox="MYBOX")
     assert not msg.seen
     assert not msg.flagged
     assert not msg.deleted
-    
+
     msg.read()
     msg.delete()
     msg.flag()
@@ -81,3 +81,18 @@ def test_set_flags_methods(IMAP4):
     assert not msg.seen
     assert not msg.flagged
     assert not msg.deleted
+
+
+def test_plain_text(IMAP4):
+    box = EmailBox(host="localhost", port=0, cls_imap=DummyGmailImap)
+
+    msg = EmailMessage(uid=3, session=box.inbox.session, mailbox="INBOX")
+
+    assert msg.subject == "redacted subject"
+    assert msg.text_body == dedent("""
+        line 1
+        line 2
+        """
+    )[1:]
+    assert msg.html_body is None
+

--- a/redbox/tests/test_fetch.py
+++ b/redbox/tests/test_fetch.py
@@ -83,7 +83,8 @@ def test_set_flags_methods(IMAP4):
     assert not msg.deleted
 
 
-def test_plain_text(IMAP4):
+
+def test_single_part_text_plain(IMAP4):
     box = EmailBox(host="localhost", port=0, cls_imap=DummyGmailImap)
 
     msg = EmailMessage(uid=3, session=box.inbox.session, mailbox="INBOX")
@@ -94,5 +95,17 @@ def test_plain_text(IMAP4):
         line 2
         """
     )[1:]
+
     assert msg.html_body is None
 
+
+def test_single_part_text_html(IMAP4):
+    box = EmailBox(host="localhost", port=0, cls_imap=DummyGmailImap)
+
+    msg = EmailMessage(uid=2, session=box.inbox.session, mailbox="INBOX")
+
+    assert msg.text_body is None
+    assert msg.html_body.strip() == dedent("""
+    <html><head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><div dir="ltr"><br></div></body></html>
+    """).strip()


### PR DESCRIPTION
Currently package fails to handle singlepart emails (see added test file).
It fails with - "TypeError: string indices must be integers".

PR adds handling singlepart email and two most common content types:
text/plain -> get_text_body
text/html -> get_html_body


