### PR TITLE
Fixing regex for identifying IMAP folders by supporting "." delimiter

### DIFF
--- a/redbox/box.py
+++ b/redbox/box.py
@@ -79,6 +79,9 @@ class EmailBox:
             # box_data is in form: 
             # - '(\\HasNoChildren) "/" INBOX'
             # - '(\\HasNoChildren) "/" "Inbox"'
+            # Flags can also be separated by periods, in the form
+            # - '(\\HasNoChildren) "." INBOX'
+            # - '(\\HasNoChildren) "." "Inbox"'
             match = re.match(r'^[(](?P<flags>[^")]+)[)] "[/.]" "?(?P<name>[^"]+)', s)
             items = match.groupdict()
             name = items['name']

--- a/redbox/box.py
+++ b/redbox/box.py
@@ -79,7 +79,7 @@ class EmailBox:
             # box_data is in form: 
             # - '(\\HasNoChildren) "/" INBOX'
             # - '(\\HasNoChildren) "/" "Inbox"'
-            match = re.match(r'^[(](?P<flags>[^")]+)[)] "/" "?(?P<name>[^"]+)', s)
+            match = re.match(r'^[(](?P<flags>[^")]+)[)] "[/.]" "?(?P<name>[^"]+)', s)
             items = match.groupdict()
             name = items['name']
             flags = items.get('flags').split(' ')


### PR DESCRIPTION
In the series of commits, I update the EmailBox class such that it supports delimiting the inbox and flags via a ".", which is the format used by some IMAP servers. I test these changes locally and observe that they work correctly.